### PR TITLE
Fixed the exception thrown when receiving a direct message

### DIFF
--- a/mokujin.py
+++ b/mokujin.py
@@ -96,7 +96,7 @@ async def on_message(message):
     if I'm going to change it.
     '''
     channel = message.channel
-    if message.content.startswith('!') and (channel.name == 'tekken' or channel.name == 'raamikysely' or channel.name == 'tekken-frames'):
+    if message.content.startswith('!') and ((isinstance(channel, discord.channel.DMChannel)) or (channel.name == 'tekken' or channel.name == 'raamikysely' or channel.name == 'tekken-frames')):
 
         user_message = message.content
         user_message = user_message.replace('!', '')


### PR DESCRIPTION
The bot used to throw an exception when receiving a direct message because direct messages do not have a channel name. With this commit the bot will respond to frame data queries in direct messages